### PR TITLE
Fix pause timing and reset message

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -356,6 +356,7 @@ class Tetris {
     pause(){
         if(this.gameStatus === "S"){
             this.gameStatus = "P";
+            clearTimeout(this.timeoutId);
         }else{
             this.gameStatus = "S";
             this.mainLoop();
@@ -377,6 +378,7 @@ class Tetris {
         this.gameSpeed = 1050;
         this.level = 1;
         this.gameStatus = "S";
+        document.getElementById("message").innerText = "";
         document.getElementById("lines").innerText = "" + this.deletedLines;
         document.getElementById("level").innerText = "" + this.level;
         this.startGame();


### PR DESCRIPTION
## Summary
- pause should clear the fall timer immediately
- reset should clear the GAME OVER message

## Testing
- `node --check tetris.js`

------
https://chatgpt.com/codex/tasks/task_e_687ed83856c0832aaa605aa7e7b61238